### PR TITLE
feat(platforms): wire real Desktop download links for v0.1.2

### DIFF
--- a/src/components/Platforms/Platforms.tsx
+++ b/src/components/Platforms/Platforms.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useTranslations } from "next-intl";
 import { Icon } from "@iconify/react";
-import { downloads } from "@/config/downloads";
+import { downloads, anyEnabled, type DownloadVariant, type LinuxFormat } from "@/config/downloads";
 
 type Os = "mac" | "win" | "linux";
 type Selection = Os | null;
@@ -24,6 +24,12 @@ function detectOs(): Os | null {
   if (/Windows/.test(ua)) return "win";
   if (/Linux|X11/.test(ua)) return "linux";
   return null;
+}
+
+function variantsFor(os: Os): readonly DownloadVariant[] {
+  if (os === "mac") return [downloads.macos.arm64, downloads.macos.x64];
+  if (os === "win") return [downloads.windows.x64, downloads.windows.arm64];
+  return downloads.linux.formats;
 }
 
 export default function Platforms() {
@@ -100,7 +106,11 @@ export default function Platforms() {
         </div>
 
         {selected ? (
-          <ComingSoonCard os={selected} />
+          anyEnabled(variantsFor(selected)) ? (
+            <DownloadCard os={selected} />
+          ) : (
+            <ComingSoonCard os={selected} />
+          )
         ) : (
           <p className="mt-8 text-sm text-white-40">{t("select_prompt")}</p>
         )}
@@ -109,12 +119,95 @@ export default function Platforms() {
   );
 }
 
+function DownloadCard({ os }: { os: Os }) {
+  const t = useTranslations("Platforms");
+  const variants = variantsFor(os).filter((v) => v.enabled);
+
+  return (
+    <div
+      role="tabpanel"
+      id={`platforms-panel-${os}`}
+      aria-labelledby={`platforms-tab-${os}`}
+      tabIndex={0}
+      className="mt-8 rounded-2xl border border-border bg-[var(--glass-t2-bg)] p-8 backdrop-blur-[12px] backdrop-saturate-[1.2]"
+    >
+      <div className="flex items-start gap-6">
+        <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-xl bg-navy">
+          <Icon
+            icon={ICONS[os]}
+            width={32}
+            height={32}
+            className="text-sky"
+            aria-hidden="true"
+          />
+        </div>
+        <div className="flex-1">
+          <div className="flex flex-wrap items-center gap-3">
+            <h3 className="text-lg font-normal text-text-primary">
+              {t(`panel_${os}_title`)}
+            </h3>
+            <span className="inline-flex items-center gap-2 rounded-full border border-[#22C55E]/30 bg-[#22C55E]/10 px-3 py-1 text-xs font-light tracking-wide text-[#22C55E]">
+              {t("available_label", { version: downloads.version })}
+            </span>
+          </div>
+          <p className="mt-2 text-sm leading-relaxed text-white-70">
+            {t(`panel_${os}_desc`)}
+          </p>
+
+          <div className="mt-5 flex flex-wrap gap-2">
+            {variants.map((v) => {
+              const format = isLinuxFormat(v) ? v.type : undefined;
+              return (
+                <a
+                  key={v.url}
+                  href={v.url}
+                  rel="noopener noreferrer"
+                  data-download-os={os}
+                  data-download-format={format}
+                  className="inline-flex min-h-11 items-center gap-2 rounded-full border border-accent/30 bg-accent/10 px-5 py-2 text-sm font-light text-accent transition-colors hover:border-accent/50 hover:bg-accent/20"
+                >
+                  <Icon icon="simple-icons:github" width={16} height={16} aria-hidden="true" />
+                  {v.label}
+                </a>
+              );
+            })}
+          </div>
+
+          {os === "win" && (
+            <p className="mt-4 text-xs text-white-40">{t("windows_smartscreen_note")}</p>
+          )}
+
+          <div className="mt-6 flex flex-wrap items-center gap-x-6 gap-y-2">
+            <a
+              href="https://github.com/getdictus/dictus-desktop/releases"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex min-h-11 items-center gap-2 text-sm text-white-70 underline underline-offset-4 hover:text-text-primary"
+            >
+              {t("view_all_releases")}
+            </a>
+            <a
+              href="https://github.com/getdictus/dictus-desktop"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex min-h-11 items-center gap-2 text-sm text-accent underline underline-offset-4 hover:text-accent-hi"
+            >
+              <Icon icon="simple-icons:github" width={16} height={16} aria-hidden="true" />
+              {t("star_on_github")}
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function isLinuxFormat(v: DownloadVariant): v is LinuxFormat {
+  return "type" in v;
+}
+
 function ComingSoonCard({ os }: { os: Os }) {
   const t = useTranslations("Platforms");
-  // Touch the config so TS narrows and the reviewer sees downloads is wired in,
-  // even though v1 renders the same Coming Soon state for every OS.
-  // (Future: branch on `downloads.macos.arm64.enabled` to render active CTA.)
-  void downloads;
 
   return (
     <div
@@ -153,20 +246,12 @@ function ComingSoonCard({ os }: { os: Os }) {
           </div>
 
           <a
-            href="https://github.com/Pivii/dictus"
+            href="https://github.com/getdictus/dictus-desktop"
             target="_blank"
             rel="noopener noreferrer"
             className="mt-6 inline-flex min-h-11 items-center gap-2 text-sm text-accent underline underline-offset-4 hover:text-accent-hi"
           >
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-              aria-hidden="true"
-            >
-              <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
-            </svg>
+            <Icon icon="simple-icons:github" width={16} height={16} aria-hidden="true" />
             {t("star_on_github")}
           </a>
         </div>

--- a/src/config/downloads.ts
+++ b/src/config/downloads.ts
@@ -1,7 +1,11 @@
 // src/config/downloads.ts
 // Centralized download links for Dictus Desktop (Mac / Windows / Linux).
-// Placeholders only — every variant is `enabled: false` until binaries ship.
+// URLs point to a pinned GitHub release — bump DESKTOP_VERSION on each new
+// dictus-desktop release and GitHub serves the matching assets automatically.
 // Shape convention mirrors src/config/donate.ts (`as const`).
+
+const DESKTOP_VERSION = "v0.1.2";
+const RELEASE_BASE = `https://github.com/getdictus/dictus-desktop/releases/download/${DESKTOP_VERSION}`;
 
 export type DownloadVariant = {
   readonly enabled: boolean;
@@ -11,9 +15,11 @@ export type DownloadVariant = {
 
 export type LinuxFormat = DownloadVariant & {
   readonly type: "appimage" | "deb" | "rpm" | "flatpak";
+  readonly arch: "x64" | "arm64";
 };
 
 export type DownloadsConfig = {
+  readonly version: string;
   readonly macos: {
     readonly arm64: DownloadVariant;
     readonly x64: DownloadVariant;
@@ -28,19 +34,75 @@ export type DownloadsConfig = {
 };
 
 export const downloads: DownloadsConfig = {
+  version: DESKTOP_VERSION,
   macos: {
-    arm64: { enabled: false, url: "", label: "Coming Soon" },
-    x64:   { enabled: false, url: "", label: "Coming Soon" },
+    arm64: {
+      enabled: true,
+      url: `${RELEASE_BASE}/Dictus_0.1.2_aarch64.dmg`,
+      label: "Apple Silicon (.dmg)",
+    },
+    x64: {
+      enabled: true,
+      url: `${RELEASE_BASE}/Dictus_0.1.2_x64.dmg`,
+      label: "Intel (.dmg)",
+    },
   },
   windows: {
-    x64:   { enabled: false, url: "", label: "Coming Soon" },
-    arm64: { enabled: false, url: "", label: "Coming Soon" },
+    x64: {
+      enabled: true,
+      url: `${RELEASE_BASE}/Dictus_0.1.2_x64-setup.exe`,
+      label: "x64 installer (.exe)",
+    },
+    arm64: {
+      enabled: true,
+      url: `${RELEASE_BASE}/Dictus_0.1.2_arm64-setup.exe`,
+      label: "ARM64 installer (.exe)",
+    },
   },
   linux: {
     formats: [
-      { type: "appimage", enabled: false, url: "", label: "Coming Soon" },
-      { type: "deb",      enabled: false, url: "", label: "Coming Soon" },
-      { type: "rpm",      enabled: false, url: "", label: "Coming Soon" },
+      {
+        type: "appimage",
+        arch: "x64",
+        enabled: true,
+        url: `${RELEASE_BASE}/Dictus_0.1.2_amd64.AppImage`,
+        label: "AppImage (x64)",
+      },
+      {
+        type: "appimage",
+        arch: "arm64",
+        enabled: true,
+        url: `${RELEASE_BASE}/Dictus_0.1.2_aarch64.AppImage`,
+        label: "AppImage (ARM64)",
+      },
+      {
+        type: "deb",
+        arch: "x64",
+        enabled: true,
+        url: `${RELEASE_BASE}/Dictus_0.1.2_amd64.deb`,
+        label: ".deb (x64)",
+      },
+      {
+        type: "deb",
+        arch: "arm64",
+        enabled: true,
+        url: `${RELEASE_BASE}/Dictus_0.1.2_arm64.deb`,
+        label: ".deb (ARM64)",
+      },
+      {
+        type: "rpm",
+        arch: "x64",
+        enabled: true,
+        url: `${RELEASE_BASE}/Dictus-0.1.2-1.x86_64.rpm`,
+        label: ".rpm (x64)",
+      },
+      {
+        type: "rpm",
+        arch: "arm64",
+        enabled: true,
+        url: `${RELEASE_BASE}/Dictus-0.1.2-1.aarch64.rpm`,
+        label: ".rpm (ARM64)",
+      },
     ],
   },
 } as const;

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -145,21 +145,24 @@
     "compatibility_text": "Dictus runs on iOS 18+ (beta), Android (beta), and macOS, Windows, Linux (coming soon)."
   },
   "Platforms": {
-    "heading": "Also coming to Desktop",
-    "subheading": "Dictus is expanding to macOS, Windows, and Linux. Same 100% offline guarantee.",
+    "heading": "Also on Desktop",
+    "subheading": "Dictus runs on macOS, Windows, and Linux. Same 100% offline guarantee.",
     "tablist_label": "Desktop platforms",
     "tab_mac": "macOS",
     "tab_win": "Windows",
     "tab_linux": "Linux",
     "panel_mac_title": "macOS",
-    "panel_mac_desc": "Apple Silicon (arm64) and Intel (x64). Native app, no login, no telemetry.",
+    "panel_mac_desc": "Apple Silicon (arm64) and Intel (x64). Signed and notarized. No login, no telemetry.",
     "panel_win_title": "Windows",
-    "panel_win_desc": "Windows 10/11, x64 and ARM. Installer and MSI.",
+    "panel_win_desc": "Windows 10/11, x64 and ARM64. Standalone installer.",
     "panel_linux_title": "Linux",
-    "panel_linux_desc": "AppImage (universal), .deb (Ubuntu/Debian), .rpm (Fedora/openSUSE).",
+    "panel_linux_desc": "AppImage (universal), .deb (Ubuntu/Debian), .rpm (Fedora/openSUSE). x64 and ARM64.",
     "coming_soon_label": "Coming Soon",
+    "available_label": "Available — {version}",
     "select_prompt": "Pick a platform to see details.",
-    "star_on_github": "Star on GitHub to follow progress"
+    "star_on_github": "Source code on GitHub",
+    "view_all_releases": "All releases & changelogs",
+    "windows_smartscreen_note": "Microsoft-trusted signing is in progress. Until then, Windows SmartScreen will show a warning — click \"More info\" then \"Run anyway\". The installer is cryptographically signed with Dictus's Ed25519 key."
   },
   "Donate": {
     "meta_title": "Support Dictus - Contribution",

--- a/src/messages/fr.json
+++ b/src/messages/fr.json
@@ -146,20 +146,23 @@
   },
   "Platforms": {
     "heading": "Aussi sur Desktop",
-    "subheading": "Dictus arrive sur macOS, Windows et Linux. La m\u00eame garantie 100% offline.",
+    "subheading": "Dictus fonctionne sur macOS, Windows et Linux. La m\u00eame garantie 100% offline.",
     "tablist_label": "Plateformes Desktop",
     "tab_mac": "macOS",
     "tab_win": "Windows",
     "tab_linux": "Linux",
     "panel_mac_title": "macOS",
-    "panel_mac_desc": "Apple Silicon (arm64) et Intel (x64). App native, sans compte, sans t\u00e9l\u00e9m\u00e9trie.",
+    "panel_mac_desc": "Apple Silicon (arm64) et Intel (x64). Sign\u00e9 et notaris\u00e9. Sans compte, sans t\u00e9l\u00e9m\u00e9trie.",
     "panel_win_title": "Windows",
-    "panel_win_desc": "Windows 10/11, x64 et ARM. Installeur et MSI.",
+    "panel_win_desc": "Windows 10/11, x64 et ARM64. Installeur autonome.",
     "panel_linux_title": "Linux",
-    "panel_linux_desc": "AppImage (universel), .deb (Ubuntu/Debian), .rpm (Fedora/openSUSE).",
+    "panel_linux_desc": "AppImage (universel), .deb (Ubuntu/Debian), .rpm (Fedora/openSUSE). x64 et ARM64.",
     "coming_soon_label": "Bient\u00f4t disponible",
+    "available_label": "Disponible \u2014 {version}",
     "select_prompt": "S\u00e9lectionnez une plateforme pour voir les d\u00e9tails.",
-    "star_on_github": "Star sur GitHub pour suivre l\u2019avanc\u00e9e"
+    "star_on_github": "Code source sur GitHub",
+    "view_all_releases": "Toutes les versions & changelogs",
+    "windows_smartscreen_note": "La signature Microsoft est en cours. En attendant, Windows SmartScreen affiche un avertissement \u2014 cliquez \u00ab Informations compl\u00e9mentaires \u00bb puis \u00ab Ex\u00e9cuter quand m\u00eame \u00bb. L'installeur est sign\u00e9 cryptographiquement avec la cl\u00e9 Ed25519 de Dictus."
   },
   "Donate": {
     "meta_title": "Soutenir Dictus - Contribution",


### PR DESCRIPTION
## Summary
- Activate Platforms section now that Dictus Desktop has shipped (v0.1.0 → v0.1.2 on GitHub)
- `downloads.ts`: all variants `enabled: true`, URLs point to pinned v0.1.2 release assets (macOS arm64/x64, Windows x64/arm64, Linux AppImage/.deb/.rpm in both archs)
- `Platforms.tsx`: new `DownloadCard` with per-variant buttons, "Available — vX" badge, Windows SmartScreen note, releases + repo links. `ComingSoonCard` preserved for future platforms. Stale `github.com/Pivii/dictus` link fixed to real `github.com/getdictus/dictus-desktop`
- i18n (EN + FR): heading reworded to "Also on Desktop" / "Aussi sur Desktop", platform descs updated (signed & notarized macOS, x64 + ARM64 across the board), 3 new keys (`available_label`, `view_all_releases`, `windows_smartscreen_note`)

## Release workflow (for now)
URLs are pinned to v0.1.2. On each `dictus-desktop` release, bump the `DESKTOP_VERSION` constant + the 10 filenames in `downloads.ts`, commit, merge. No Vercel env var changes. A follow-up issue will track moving to a fully automated build-time fetch + deploy-hook pipeline.

## Test plan
- [x] `npm run lint` → 0 errors
- [x] `npx tsc --noEmit` → clean
- [x] `npm run build` → 15 static pages generated OK
- [x] Dev server smoke test — EN/FR sections render with new copy
- [ ] Verify Platforms section on Vercel preview
- [ ] Click each variant, confirm GitHub download starts
- [ ] Check Windows SmartScreen note shows only on Windows tab