### PR TITLE
chore(platforms): auto-sync Desktop downloads with latest release (#8)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,14 @@ BTCPAY_WEBHOOK_SECRET=
 # Needed because InvoiceSettled webhook payload does NOT include amount/currency —
 # we fetch invoice details via GET /api/v1/stores/{storeId}/invoices/{invoiceId}
 BTCPAY_API_KEY=
+
+# --- Phase issue#8: Desktop downloads auto-sync (optional) ---
+
+# GitHub API token used by getDesktopDownloads() at build/ISR time to resolve
+# the latest dictus-desktop release. Optional — lifts the unauthenticated rate
+# limit from 60 req/h to 5000 req/h.
+#
+# Use a fine-grained PAT with NO scopes (the dictus-desktop repo is public —
+# read-only public access is all that's needed). Server-only, never exposed to
+# the browser. DO NOT prefix with NEXT_PUBLIC_.
+GITHUB_TOKEN=

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,4 +1,5 @@
 import { setRequestLocale, getTranslations } from "next-intl/server";
+import { getDesktopDownloads } from "@/lib/downloads";
 import Hero from "@/components/Hero/Hero";
 import Platforms from "@/components/Platforms/Platforms";
 import Features from "@/components/Features/Features";
@@ -19,6 +20,7 @@ export default async function HomePage({ params }: Props) {
   setRequestLocale(locale);
 
   const t = await getTranslations("Metadata");
+  const downloads = await getDesktopDownloads();
 
   const jsonLd = {
     "@context": "https://schema.org",
@@ -41,7 +43,7 @@ export default async function HomePage({ params }: Props) {
   return (
     <>
       <Hero />
-      <ScrollReveal><Platforms /></ScrollReveal>
+      <ScrollReveal><Platforms downloads={downloads} /></ScrollReveal>
       <ScrollReveal><Features /></ScrollReveal>
       <ScrollReveal><Comparison /></ScrollReveal>
       <ScrollReveal><HowItWorks /></ScrollReveal>

--- a/src/components/Platforms/Platforms.tsx
+++ b/src/components/Platforms/Platforms.tsx
@@ -3,7 +3,12 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useTranslations } from "next-intl";
 import { Icon } from "@iconify/react";
-import { downloads, anyEnabled, type DownloadVariant, type LinuxFormat } from "@/config/downloads";
+import {
+  anyEnabled,
+  type DownloadsConfig,
+  type DownloadVariant,
+  type LinuxFormat,
+} from "@/config/downloads";
 
 type Os = "mac" | "win" | "linux";
 type Selection = Os | null;
@@ -26,13 +31,16 @@ function detectOs(): Os | null {
   return null;
 }
 
-function variantsFor(os: Os): readonly DownloadVariant[] {
+function variantsFor(
+  downloads: DownloadsConfig,
+  os: Os
+): readonly DownloadVariant[] {
   if (os === "mac") return [downloads.macos.arm64, downloads.macos.x64];
   if (os === "win") return [downloads.windows.x64, downloads.windows.arm64];
   return downloads.linux.formats;
 }
 
-export default function Platforms() {
+export default function Platforms({ downloads }: { downloads: DownloadsConfig }) {
   const t = useTranslations("Platforms");
   const [selected, setSelected] = useState<Selection>(null);
   const tabsRef = useRef<(HTMLButtonElement | null)[]>([]);
@@ -106,8 +114,8 @@ export default function Platforms() {
         </div>
 
         {selected ? (
-          anyEnabled(variantsFor(selected)) ? (
-            <DownloadCard os={selected} />
+          anyEnabled(variantsFor(downloads, selected)) ? (
+            <DownloadCard os={selected} downloads={downloads} />
           ) : (
             <ComingSoonCard os={selected} />
           )
@@ -119,9 +127,9 @@ export default function Platforms() {
   );
 }
 
-function DownloadCard({ os }: { os: Os }) {
+function DownloadCard({ os, downloads }: { os: Os; downloads: DownloadsConfig }) {
   const t = useTranslations("Platforms");
-  const variants = variantsFor(os).filter((v) => v.enabled);
+  const variants = variantsFor(downloads, os).filter((v) => v.enabled);
 
   return (
     <div

--- a/src/config/downloads.ts
+++ b/src/config/downloads.ts
@@ -1,8 +1,15 @@
 // src/config/downloads.ts
-// Centralized download links for Dictus Desktop (Mac / Windows / Linux).
-// URLs point to a pinned GitHub release — bump DESKTOP_VERSION on each new
-// dictus-desktop release and GitHub serves the matching assets automatically.
-// Shape convention mirrors src/config/donate.ts (`as const`).
+// Desktop download config for Dictus Desktop (Mac / Windows / Linux).
+//
+// Runtime source of truth is the GitHub Releases API — resolved at build time by
+// `getDesktopDownloads()` in `src/lib/downloads.ts`. This module provides:
+//   1. The type contract (`DownloadsConfig`, variants).
+//   2. A pinned `fallbackDownloads` snapshot used when the API call fails.
+//   3. `ASSET_PATTERNS` — anchored regexes that match each variant slot to an
+//      asset in the release's `assets[]` array.
+//
+// Bump `DESKTOP_VERSION` + the fallback URLs only as a manual safety net; the
+// live site auto-syncs with the latest release without needing changes here.
 
 const DESKTOP_VERSION = "v0.1.2";
 const RELEASE_BASE = `https://github.com/getdictus/dictus-desktop/releases/download/${DESKTOP_VERSION}`;
@@ -33,7 +40,7 @@ export type DownloadsConfig = {
   };
 };
 
-export const downloads: DownloadsConfig = {
+export const fallbackDownloads: DownloadsConfig = {
   version: DESKTOP_VERSION,
   macos: {
     arm64: {
@@ -105,6 +112,23 @@ export const downloads: DownloadsConfig = {
       },
     ],
   },
+} as const;
+
+// Anchored regexes that match each variant slot to an asset filename.
+// Both ends anchored + required `Dictus` prefix block mis-named / attacker-
+// injected assets from matching. Kept alongside the config so changes stay
+// co-located with the data shape.
+export const ASSET_PATTERNS = {
+  macArm64: /^Dictus_[\d.]+_aarch64\.dmg$/,
+  macX64: /^Dictus_[\d.]+_x64\.dmg$/,
+  winX64: /^Dictus_[\d.]+_x64-setup\.exe$/,
+  winArm64: /^Dictus_[\d.]+_arm64-setup\.exe$/,
+  linuxAppX64: /^Dictus_[\d.]+_amd64\.AppImage$/,
+  linuxAppArm64: /^Dictus_[\d.]+_aarch64\.AppImage$/,
+  linuxDebX64: /^Dictus_[\d.]+_amd64\.deb$/,
+  linuxDebArm64: /^Dictus_[\d.]+_arm64\.deb$/,
+  linuxRpmX64: /^Dictus-[\d.]+-\d+\.x86_64\.rpm$/,
+  linuxRpmArm64: /^Dictus-[\d.]+-\d+\.aarch64\.rpm$/,
 } as const;
 
 // Convenience helper used by the Platforms component to decide

--- a/src/lib/downloads.ts
+++ b/src/lib/downloads.ts
@@ -1,0 +1,124 @@
+// src/lib/downloads.ts
+// Server-only: resolves Desktop download URLs from the live GitHub Releases API
+// at build / ISR time. Falls back to `fallbackDownloads` on any failure so
+// builds never break and the site stays usable if the API is unreachable.
+//
+// Primary refresh path is a Vercel Deploy Hook triggered by the dictus-desktop
+// release workflow. The `revalidate: 3600` below is a safety net for missed
+// hooks (1h ISR).
+
+import {
+  fallbackDownloads,
+  ASSET_PATTERNS,
+  type DownloadsConfig,
+  type DownloadVariant,
+  type LinuxFormat,
+} from "@/config/downloads";
+
+const RELEASES_URL =
+  "https://api.github.com/repos/getdictus/dictus-desktop/releases/latest";
+const ALLOWED_URL_PREFIX =
+  "https://github.com/getdictus/dictus-desktop/releases/download/";
+const TAG_REGEX = /^v\d+\.\d+\.\d+(?:-[a-z0-9.-]+)?$/i;
+const FETCH_TIMEOUT_MS = 10_000;
+const REVALIDATE_SECONDS = 3600;
+
+type Asset = { name: string; browser_download_url: string };
+
+function isValidAsset(a: unknown): a is Asset {
+  if (!a || typeof a !== "object") return false;
+  const x = a as Record<string, unknown>;
+  return (
+    typeof x.name === "string" &&
+    typeof x.browser_download_url === "string" &&
+    x.browser_download_url.startsWith(ALLOWED_URL_PREFIX)
+  );
+}
+
+function resolveVariant(
+  fallback: DownloadVariant,
+  url: string | undefined
+): DownloadVariant {
+  if (!url) return fallback;
+  return { enabled: true, url, label: fallback.label };
+}
+
+function resolveLinuxFormat(
+  fallback: LinuxFormat,
+  url: string | undefined
+): LinuxFormat {
+  if (!url) return fallback;
+  return {
+    type: fallback.type,
+    arch: fallback.arch,
+    enabled: true,
+    url,
+    label: fallback.label,
+  };
+}
+
+function linuxPatternFor(fmt: LinuxFormat): RegExp | null {
+  if (fmt.type === "appimage" && fmt.arch === "x64") return ASSET_PATTERNS.linuxAppX64;
+  if (fmt.type === "appimage" && fmt.arch === "arm64") return ASSET_PATTERNS.linuxAppArm64;
+  if (fmt.type === "deb" && fmt.arch === "x64") return ASSET_PATTERNS.linuxDebX64;
+  if (fmt.type === "deb" && fmt.arch === "arm64") return ASSET_PATTERNS.linuxDebArm64;
+  if (fmt.type === "rpm" && fmt.arch === "x64") return ASSET_PATTERNS.linuxRpmX64;
+  if (fmt.type === "rpm" && fmt.arch === "arm64") return ASSET_PATTERNS.linuxRpmArm64;
+  return null;
+}
+
+export async function getDesktopDownloads(): Promise<DownloadsConfig> {
+  try {
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    };
+    const token = process.env.GITHUB_TOKEN;
+    if (token) headers.Authorization = `Bearer ${token}`;
+
+    const res = await fetch(RELEASES_URL, {
+      headers,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      next: { revalidate: REVALIDATE_SECONDS },
+    });
+    if (!res.ok) return fallbackDownloads;
+
+    const data: unknown = await res.json();
+    if (!data || typeof data !== "object") return fallbackDownloads;
+    const obj = data as Record<string, unknown>;
+
+    const tag =
+      typeof obj.tag_name === "string" && TAG_REGEX.test(obj.tag_name)
+        ? obj.tag_name
+        : null;
+    if (!tag) return fallbackDownloads;
+
+    const assets = Array.isArray(obj.assets)
+      ? obj.assets.filter(isValidAsset)
+      : [];
+    if (assets.length === 0) return fallbackDownloads;
+
+    const find = (re: RegExp): string | undefined =>
+      assets.find((a) => re.test(a.name))?.browser_download_url;
+
+    return {
+      version: tag,
+      macos: {
+        arm64: resolveVariant(fallbackDownloads.macos.arm64, find(ASSET_PATTERNS.macArm64)),
+        x64: resolveVariant(fallbackDownloads.macos.x64, find(ASSET_PATTERNS.macX64)),
+      },
+      windows: {
+        x64: resolveVariant(fallbackDownloads.windows.x64, find(ASSET_PATTERNS.winX64)),
+        arm64: resolveVariant(fallbackDownloads.windows.arm64, find(ASSET_PATTERNS.winArm64)),
+      },
+      linux: {
+        formats: fallbackDownloads.linux.formats.map((fmt) => {
+          const pattern = linuxPatternFor(fmt);
+          return resolveLinuxFormat(fmt, pattern ? find(pattern) : undefined);
+        }),
+      },
+    };
+  } catch {
+    return fallbackDownloads;
+  }
+}


### PR DESCRIPTION
Closes #8.

## Summary

- Replaces hardcoded `DESKTOP_VERSION = "v0.1.2"` in `src/config/downloads.ts` with a build/ISR-time fetch against `GET /repos/getdictus/dictus-desktop/releases/latest`.
- New `src/lib/downloads.ts` server helper resolves asset URLs by filename regex, returns `fallbackDownloads` on any failure so builds never break.
- `Platforms.tsx` now takes `downloads` as a prop (hoisted fetch in `src/app/[locale]/page.tsx`).
- `ISR revalidate: 3600` is the belt-and-suspenders safety net. Primary refresh path is the Vercel Deploy Hook (see follow-ups below).

## Security hardening

- **URL allowlist**: every `browser_download_url` validated against `https://github.com/getdictus/dictus-desktop/releases/download/` prefix.
- **Anchored asset regexes**: `^Dictus[_-]...$` — blocks mis-named / injected assets.
- **Tag validation**: strict `^v\d+\.\d+\.\d+(-...)?$` before interpolation into the i18n "Available — {version}" badge.
- **Timeout**: 10s via `AbortSignal.timeout` — no build hang on slow API.
- **Shape validation**: `typeof` guards + `try/catch` wrap the entire path; malformed JSON → fallback.
- **Secret hygiene**: optional `GITHUB_TOKEN` read server-side only (no `NEXT_PUBLIC_` prefix). Fine-grained PAT with **no scopes** suffices (public repo). Not required.
- **Rate limit**: build-time + 1h ISR ≈ ~24 req/day per region — well under the 60/h unauth limit.

## Verification

- [x] `npm run build` succeeds.
- [x] Prerendered `/en` and `/fr` HTML contain the 10 live v0.1.2 asset URLs (all slots matched against the live release).
- [x] `npx tsc --noEmit` clean.
- [x] `npm run lint` — 0 new errors.
- [ ] Manually verify `/en` and `/fr` Platforms section after Vercel preview deploy.

## Follow-ups (out of scope for this PR)

These complete AC but live outside this repo:

- [ ] **Vercel dashboard**: create Deploy Hook on `main` branch (Settings → Git → Deploy Hooks), name `dictus-desktop release trigger`.
- [ ] **dictus-desktop repo**: store the hook URL as secret `VERCEL_WEBSITE_DEPLOY_HOOK` and add to the release workflow:
  ```yaml
  - name: Trigger getdictus.com rebuild
    if: success()
    run: curl -X POST "${{ secrets.VERCEL_WEBSITE_DEPLOY_HOOK }}"
  ```
- [ ] (Optional) Set `GITHUB_TOKEN` in Vercel project env vars to lift rate limit — not required; the site works fine unauthenticated.

Without the deploy hook the site still auto-refreshes every hour via ISR — the hook just makes it near-instant after a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)