### PR TITLE
feat(hero): add Also on Desktop link to hero CTAs

### DIFF
--- a/src/components/Hero/AdaptiveCTA.tsx
+++ b/src/components/Hero/AdaptiveCTA.tsx
@@ -45,6 +45,37 @@ function AndroidIcon() {
   );
 }
 
+function DesktopIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="2" y="3" width="20" height="14" rx="2" />
+      <path d="M8 21h8M12 17v4" />
+    </svg>
+  );
+}
+
+function DesktopLink({ label }: { label: string }) {
+  return (
+    <a
+      href="#desktop"
+      className="inline-flex items-center gap-1.5 text-xs text-white-40 underline-offset-4 transition-colors hover:text-accent hover:underline"
+    >
+      <DesktopIcon />
+      {label}
+    </a>
+  );
+}
+
 function Badge({
   icon,
   label,
@@ -109,15 +140,18 @@ export default function AdaptiveCTA() {
   // Pre-hydration: show dual badges
   if (device === "unknown") {
     return (
-      <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
-        <Badge
-          icon={<AppleIcon />}
-          label={betaActive ? t("badge_ios_beta") : t("badge_ios")}
-        />
-        <Badge
-          icon={<AndroidIcon />}
-          label={betaActive ? t("badge_android_beta") : t("badge_android")}
-        />
+      <div className="mt-6 flex flex-col items-center gap-3">
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <Badge
+            icon={<AppleIcon />}
+            label={betaActive ? t("badge_ios_beta") : t("badge_ios")}
+          />
+          <Badge
+            icon={<AndroidIcon />}
+            label={betaActive ? t("badge_android_beta") : t("badge_android")}
+          />
+        </div>
+        <DesktopLink label={t("cta_desktop")} />
       </div>
     );
   }
@@ -136,6 +170,7 @@ export default function AdaptiveCTA() {
             {t("cta_android_download")}
           </SecondaryLink>
         )}
+        <DesktopLink label={t("cta_desktop")} />
       </div>
     );
   }
@@ -154,6 +189,7 @@ export default function AdaptiveCTA() {
             {t("cta_testflight_link")} (iOS)
           </SecondaryLink>
         )}
+        <DesktopLink label={t("cta_desktop")} />
       </div>
     );
   }
@@ -179,15 +215,19 @@ export default function AdaptiveCTA() {
             </a>
           )}
         </div>
+        <DesktopLink label={t("cta_desktop")} />
       </div>
     );
   }
 
   // Fallback: dual badges (no URLs configured)
   return (
-    <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
-      <Badge icon={<AppleIcon />} label={t("badge_ios")} />
-      <Badge icon={<AndroidIcon />} label={t("badge_android")} />
+    <div className="mt-6 flex flex-col items-center gap-3">
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <Badge icon={<AppleIcon />} label={t("badge_ios")} />
+        <Badge icon={<AndroidIcon />} label={t("badge_android")} />
+      </div>
+      <DesktopLink label={t("cta_desktop")} />
     </div>
   );
 }

--- a/src/components/Platforms/Platforms.tsx
+++ b/src/components/Platforms/Platforms.tsx
@@ -68,7 +68,7 @@ export default function Platforms({ downloads }: { downloads: DownloadsConfig })
   );
 
   return (
-    <section className="bg-ink-2 py-28" aria-labelledby="platforms-heading">
+    <section id="desktop" className="scroll-mt-16 bg-ink-2 py-28" aria-labelledby="platforms-heading">
       <div className="mx-auto max-w-6xl px-6">
         <h2
           id="platforms-heading"

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -22,7 +22,8 @@
     "cta_scan_to_join": "Scan to join the beta",
     "cta_available_iphone": "Available on iPhone",
     "cta_testflight_link": "Open in TestFlight",
-    "cta_android_soon": "Also coming to Android"
+    "cta_android_soon": "Also coming to Android",
+    "cta_desktop": "Also on Desktop"
   },
   "Features": {
     "privacy_title": "100% offline",

--- a/src/messages/fr.json
+++ b/src/messages/fr.json
@@ -22,7 +22,8 @@
     "cta_scan_to_join": "Scannez pour rejoindre la beta",
     "cta_available_iphone": "Disponible sur iPhone",
     "cta_testflight_link": "Ouvrir dans TestFlight",
-    "cta_android_soon": "Bient\u00f4t sur Android"
+    "cta_android_soon": "Bient\u00f4t sur Android",
+    "cta_desktop": "Aussi sur Desktop"
   },
   "Features": {
     "privacy_title": "100% offline",


### PR DESCRIPTION
## Summary
- Adds a subtle tertiary "Also on Desktop" link beneath the iOS/Android CTAs in the hero
- Link anchors to `#desktop` on the Platforms section, scrolling users to the existing desktop download UI
- Adds `cta_desktop` strings to `en.json` / `fr.json`

## Test plan
- [ ] Hero renders link under the two CTA buttons across all device variants (iPhone / Android / desktop / pre-hydration / fallback)
- [ ] Clicking "Also on Desktop" scrolls to the "Also on Desktop" section
- [ ] FR locale shows "Aussi sur Desktop"
- [ ] EN locale shows "Also on Desktop"

🤖 Generated with [Claude Code](https://claude.com/claude-code)